### PR TITLE
Fix SVG link

### DIFF
--- a/docs/_includes/tesselaceSample.html
+++ b/docs/_includes/tesselaceSample.html
@@ -4,7 +4,7 @@
         <figcaption>
             <a href="/{{ site.github.repository_name }}/tl/{{ include.path }}/{{ include.name }}.txt" download="{{ include.name }}.txt">{{ include.name }}.txt</a>
             -
-            <a href="/{{ site.github.repository_name }}/sheet.html?{{ include.SVG }}">svg</a>
+            <a href="/GroundForge/sheet.html?{{ include.SVG }}">svg</a>
         </figcaption>
     </a>
 </figure>

--- a/docs/_includes/tesselaceSample.html
+++ b/docs/_includes/tesselaceSample.html
@@ -4,7 +4,7 @@
         <figcaption>
             <a href="/{{ site.github.repository_name }}/tl/{{ include.path }}/{{ include.name }}.txt" download="{{ include.name }}.txt">{{ include.name }}.txt</a>
             -
-            <a href="{{ site.github.repository_name }}/sheet.html?{{ include.SVG }}">svg</a>
+            <a href="/{{ site.github.repository_name }}/sheet.html?{{ include.SVG }}">svg</a>
         </figcaption>
     </a>
 </figure>


### PR DESCRIPTION
The SVG link needs to point to GroundForge and not to tesselace-to-gf.  The "site.github.repository_name" property does not work in this case.