### PR TITLE
another kat, cross reference to GW pattern families

### DIFF
--- a/docs/6.md
+++ b/docs/6.md
@@ -7,11 +7,6 @@ Hexagon holes
 ===================
 
 {% include intro.md %}
-
-3 and 6
---------
-{% include tesselaceSample.html name="2x4_85" path="3_6" GF="/GroundForge/tiles.html?tesselace=2x4_85&patchWidth=12&patchHeight=12&tile=4-O0,9E-7&shiftColsSW=0&shiftRowsSW=2&shiftColsSE=4&shiftRowsSE=0&" SVG="patch=4-O0,9E-7;checker" %}
-
  
 3, 4 and 6
 ----------

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,8 +18,8 @@ TesseLace Index
 Traditional Grounds
 -------------------
 
-See also families of patterns in [note 5](/gw-lace-to-gf/#N5)
-of the sampler by G. Whiting.
+See [note 5](/gw-lace-to-gf/#N5)
+of the sampler by G. Whiting for a few families of patterns.
 
 ### Cloth family
 {% include tesselaceSample.html name="2x1_1" path="cloth" GF="/GroundForge/tiles.html?tesselace=2x1_1&patchWidth=12&patchHeight=12&tile=8,1&shiftColsSW=0&shiftRowsSW=2&shiftColsSE=1&shiftRowsSE=0&" SVG="patch=8,1;checker" %}

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,9 @@ TesseLace Index
 Traditional Grounds
 -------------------
 
+See also families of patterns in [note 5](/gw-lace-to-gf/#N5)
+of the sampler by G. Whiting.
+
 ### Cloth family
 {% include tesselaceSample.html name="2x1_1" path="cloth" GF="/GroundForge/tiles.html?tesselace=2x1_1&patchWidth=12&patchHeight=12&tile=8,1&shiftColsSW=0&shiftRowsSW=2&shiftColsSE=1&shiftRowsSE=0&" SVG="patch=8,1;checker" %}
 {% include tesselaceSample.html name="2x1_3" path="cloth" GF="/GroundForge/tiles.html?tesselace=2x1_3&patchWidth=12&patchHeight=12&tile=6,2&shiftColsSW=0&shiftRowsSW=2&shiftColsSE=1&shiftRowsSE=0&" SVG="patch=6,2;checker" %}
@@ -53,6 +56,7 @@ See also:
  {% include tesselaceSample.html name="2x4_28" path="3_6" GF="/GroundForge/tiles.html?tesselace=2x4_28&patchWidth=12&patchHeight=12&tile=4-L8,25-1&shiftColsSW=0&shiftRowsSW=2&shiftColsSE=4&shiftRowsSE=0&" SVG="patch=4-L8,25-1;checker" %}
  {% include tesselaceSample.html name="2x4_29" path="3_6" GF="/GroundForge/tiles.html?tesselace=2x4_29&patchWidth=12&patchHeight=12&tile=4-M9,25E-&shiftColsSW=0&shiftRowsSW=2&shiftColsSE=4&shiftRowsSE=0&" SVG="patch=4-M9,25E-;checker" %}
  {% include tesselaceSample.html name="2x4_49" path="3_6" GF="/GroundForge/tiles.html?tesselace=2x4_49&patchWidth=12&patchHeight=12&tile=68-7,-124&shiftColsSW=0&shiftRowsSW=2&shiftColsSE=4&shiftRowsSE=0&" SVG="patch=68-7,-124;checker" %}
+ {% include tesselaceSample.html name="2x4_85" path="3_6" GF="/GroundForge/tiles.html?tesselace=2x4_85&patchWidth=12&patchHeight=12&tile=4-O0,9E-7&shiftColsSW=0&shiftRowsSW=2&shiftColsSE=4&shiftRowsSE=0&" SVG="patch=4-O0,9E-7;checker" %}
  {% include tesselaceSample.html name="2x4_86" path="3_6" GF="/GroundForge/tiles.html?tesselace=2x4_86&patchWidth=12&patchHeight=12&tile=4-O0,O04-&shiftColsSW=0&shiftRowsSW=2&shiftColsSE=4&shiftRowsSE=0&" SVG="patch=4-O0,O04-;checker" %}
  {% include tesselaceSample.html name="2x4_93" path="3_6" GF="/GroundForge/tiles.html?tesselace=2x4_93&patchWidth=12&patchHeight=12&tile=58-1,-158&shiftColsSW=0&shiftRowsSW=2&shiftColsSE=4&shiftRowsSE=0&" SVG="patch=58-1,-158;checker" %}
  {% include tesselaceSample.html name="2x4_96" path="3_6" GF="/GroundForge/tiles.html?tesselace=2x4_96&patchWidth=12&patchHeight=12&tile=5831,-4-7&shiftColsSW=0&shiftRowsSW=2&shiftColsSE=4&shiftRowsSE=0&" SVG="patch=5831,-4-7;checker" %}

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ Traditional Grounds
 -------------------
 
 See [note 5](/gw-lace-to-gf/#N5)
-of the sampler by G. Whiting for a few families of patterns.
+of the sampler by G. Whiting for a few more families of patterns.
 
 ### Cloth family
 {% include tesselaceSample.html name="2x1_1" path="cloth" GF="/GroundForge/tiles.html?tesselace=2x1_1&patchWidth=12&patchHeight=12&tile=8,1&shiftColsSW=0&shiftRowsSW=2&shiftColsSE=1&shiftRowsSE=0&" SVG="patch=8,1;checker" %}


### PR DESCRIPTION
I [rewrote](https://github.com/d-bl/gw-lace-to-gf/commit/5cbab3108688e98b5517547fb9b86636e0235233) note 5 on the GW page and changed the abbreviations for the pattern families.

While creating cross references with the TesseLace families of patterns I discovered that a kat stitch pattern was on the wrong page.

@d-bl/gf 